### PR TITLE
Increased max. menu options to 12

### DIFF
--- a/whapps/voip/menu/menu.js
+++ b/whapps/voip/menu/menu.js
@@ -515,7 +515,7 @@ winkstart.module('voip', 'menu', {
                     rules: [
                         {
                             type: 'quantity',
-                            maxSize: '9'
+                            maxSize: '12'
                         }
                     ],
                     isUsable: 'true',


### PR DESCRIPTION
Since there are 12 different possible menu options (0-9, *, default), increase the maximum number of options from 9 to 12. Fixes [KAZOO-2258](https://2600hz.atlassian.net/browse/KAZOO-2258).
