### PR TITLE
Add a checkbox to enable call forwarding in userportal.

### DIFF
--- a/whapps/userportal/portal_manager/css/portal_manager.css
+++ b/whapps/userportal/portal_manager/css/portal_manager.css
@@ -212,3 +212,9 @@
     color: #bbb;
     font-style: italic;
 }
+
+.portal-view #call-forward-data {
+    border:1px solid #999;
+    border-radius: 5px;
+    padding-left: 15px;
+}

--- a/whapps/userportal/portal_manager/lang/en.js
+++ b/whapps/userportal/portal_manager/lang/en.js
@@ -39,5 +39,6 @@ window.translate['portal_manager'] = {
 	voicemail_box_id: "Voicemail Box ID",
 	are_you_sure_that_you_want_to_delete: "Are you sure that you want to delete the selected voicemail message(s)?",
 	vm_to_email_txt_regex: /^(([a-zA-Z0-9_\.\-\+])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+)?$/,
-	ring_number_txt_regex: /^[\+]?[0-9\s\-\.\(\)]{7,20}$|(sip[s]?:[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-zA-Z0-9]+)$|^$/
+	ring_number_txt_regex: /^[\+]?[0-9\s\-\.\(\)]{7,20}$|(sip[s]?:[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-zA-Z0-9]+)$|^$/,
+	enable_call_forward: "Enable Call Forward"
 };

--- a/whapps/userportal/portal_manager/portal_manager.js
+++ b/whapps/userportal/portal_manager/portal_manager.js
@@ -280,7 +280,7 @@ winkstart.module('userportal', 'portal_manager', {
                 }
 
                 if(!('call_forward' in _data_settings.data) || !_data_settings.data.call_forward.enabled) {
-                    $('.device-field', portal_manager_html).hide();
+                    $('#call-forward-data', portal_manager_html).hide();
                 }
 
                 (parent)
@@ -436,6 +436,11 @@ winkstart.module('userportal', 'portal_manager', {
                 $('#vm-to-email-checkbox', portal_manager_html).attr('checked') ? $('.email-field', portal_manager_html).slideDown() : $('.email-field', portal_manager_html).slideUp();
             });
 
+            // Show/hide call forward settings based on whether call forwarding is enabled.
+            $('#call-forward-enabled', portal_manager_html).change(function() {
+                $('#call-forward-enabled', portal_manager_html).attr('checked') ? $('#call-forward-data', portal_manager_html).slideDown() : $('#call-forward-data', portal_manager_html).slideUp();
+            });
+
             $('#contact_list_btn', portal_manager_html).click(function(e) {
                 e.preventDefault();
 
@@ -451,11 +456,13 @@ winkstart.module('userportal', 'portal_manager', {
                     replaced_number = replaced_number.replace(/\s|\(|\)|\-|\./g,'');
                 }
 
+                var enabled = $('#call-forward-enabled', portal_manager_html).attr('checked');
+
                 var data = {
                     vm_to_email_enabled: false,
                     call_forward: {
                         number: replaced_number,
-                        enabled: replaced_number !== '' ? true : false,
+                        enabled: (enabled && replaced_number !== '') ? true : false,
                         substitute: $('#ring-device-checkbox', portal_manager_html).attr('checked') ? false : true,
                         keep_caller_id: $('#call_forward_keep_caller_id', portal_manager_html).attr('checked') ? true : false
                         //Substitute equals true to enable real call forwarding, false in order to ring devices as well.

--- a/whapps/userportal/portal_manager/tmpl/portal_manager.html
+++ b/whapps/userportal/portal_manager/tmpl/portal_manager.html
@@ -21,20 +21,42 @@
                 <h1>${_t('my_settings')}</h1>
                 <div id="settings-view">
                     <form>
-                        <div class="clearfix">
-                            <label><span class="icon phone"/>${_t('forward_calls_to')}:</label>
+                    <div class="clearfix">
+                            <label>${_t('enable_call_forward')}:</label>
                             <div class="input">
-                                <input id="ring-number-txt" name="ring-number-txt" type="text" value="${data.call_forward.number}"/>
-                            </div>
-                        </div>
-                        <div class="clearfix device-field">
-                            <label>${_t('also_ring_my_voip_phone')}:</label>
-                            <div class="input">
-                                {{if data.call_forward.substitute}}
-                                    <input class="checkbox" id="ring-device-checkbox" name="ring-device-checkbox" type="checkbox"/>
+                                {{if data.call_forward.enabled}}
+                                    <input class="checkbox" id="call-forward-enabled" name="call_forward.enabled" type="checkbox" checked="checked"/>
                                 {{else}}
-                                    <input class="checkbox" id="ring-device-checkbox" name="ring-device-checkbox" type="checkbox" checked="checked"/>
+                                    <input class="checkbox" id="call-forward-enabled" name="call_forward.enabled" type="checkbox"/>
                                 {{/if}}
+                             </div>
+                         </div>
+                        <div id="call-forward-data">
+                            <div class="clearfix">
+                                <label><span class="icon phone"/>${_t('forward_calls_to')}:</label>
+                                <div class="input">
+                                    <input id="ring-number-txt" name="ring-number-txt" type="text" value="${data.call_forward.number}"/>
+                                </div>
+                            </div>
+                            <div class="clearfix device-field">
+                                <label>${_t('also_ring_my_voip_phone')}:</label>
+                                <div class="input">
+                                    {{if data.call_forward.substitute}}
+                                        <input class="checkbox" id="ring-device-checkbox" name="ring-device-checkbox" type="checkbox"/>
+                                    {{else}}
+                                        <input class="checkbox" id="ring-device-checkbox" name="ring-device-checkbox" type="checkbox" checked="checked"/>
+                                    {{/if}}
+                                </div>
+                            </div>
+                            <div class="clearfix">
+                                <label>${_t('keep_caller_id')}:</label>
+                                <div class="input">
+                                    {{if data.call_forward.keep_caller_id}}
+                                        <input id="call_forward_keep_caller_id" class="checkbox" name="call_forward.keep_caller_id" type="checkbox" checked="checked"/>
+                                    {{else}}
+                                        <input id="call_forward_keep_caller_id" class="checkbox" name="call_forward.keep_caller_id" type="checkbox"/>
+                                    {{/if}}
+                                </div>
                             </div>
                         </div>
                         <div class="clearfix">
@@ -51,16 +73,6 @@
                             <label>${_t('email_address')}:</label>
                             <div class="input">
                                 <input id="vm-to-email-txt" name="vm-to-email-txt" type="text" value="${data.email}"/>
-                            </div>
-                        </div>
-                        <div class="clearfix">
-                            <label>${_t('keep_caller_id')}:</label>
-                            <div class="input">
-                                {{if data.call_forward.keep_caller_id}}
-                                    <input id="call_forward_keep_caller_id" class="checkbox" name="call_forward.keep_caller_id" type="checkbox" checked="checked"/>
-                                {{else}}
-                                    <input id="call_forward_keep_caller_id" class="checkbox" name="call_forward.keep_caller_id" type="checkbox"/>
-                                {{/if}}
                             </div>
                         </div>
                         <div class="buttons">


### PR DESCRIPTION
At the moment, you can specify what number to forward calls to, but no straight way to see whether it is enabled or not. (it will not be enabled if the number field is blank, but through the edit user screen it is possible to have a number set but not have call forwarding enabled, and vice versa).
