### PR TITLE
Only show actions (cdr details) column to reseller.

### DIFF
--- a/whapps/voip/cdr/cdr.js
+++ b/whapps/voip/cdr/cdr.js
@@ -224,7 +224,8 @@ function(args) {
             {
                 'sTitle': _t('cdr', 'actions_stitle'),
                 'sWidth': '80px',
-                'bSortable': false
+                'bSortable': false,
+		'bVisible': winkstart.apps['auth'].is_reseller || (winkstart.config.hasOwnProperty('reseller_id') ? (winkstart.config.reseller_id === winkstart.apps['auth'].account_id) : false),
             },
             {
                 'sTitle': _t('cdr', 'cost_stitle')


### PR DESCRIPTION
Way to much internal data in the details for customers to be seeing it.
