### PR TITLE
Check for 'video' as well as 'audio' in device.

### DIFF
--- a/whapps/voip/device/device.js
+++ b/whapps/voip/device/device.js
@@ -498,7 +498,9 @@ winkstart.module('voip', 'device', {
                     if(results.get_device.data.media.audio.hasOwnProperty('codecs')) {
                         render_data.data.media.audio.codecs = results.get_device.data.media.audio.codecs;
                     }
+                }
 
+                if(results.get_device.data.media.hasOwnProperty('video')) {
                     if(results.get_device.data.media.video.hasOwnProperty('codecs')) {
                         render_data.data.media.video.codecs = results.get_device.data.media.video.codecs;
                     }


### PR DESCRIPTION
If `audio` is present in the `media` object in device data, but `video` is not, device loading will fail, because the code attempts to check the video codecs when there is no `video` object.