### PR TITLE
Unique div ids, so background tabs don't change when clicking foreground tabs

### DIFF
--- a/whapps/voip/device/tmpl/edit.html
+++ b/whapps/voip/device/tmpl/edit.html
@@ -15,7 +15,7 @@
 	<div class="row">
 		<ul class="tabs" data-tabs="tabs">
 			<li class="active"><a href="#basic">${_t('basic')}</a></li>
-			<li><a href="#caller_id">${_t('caller_id')}</a></li>
+			<li><a href="#caller_id_device">${_t('caller_id')}</a></li>
 			<li><a href="#sip_settings">${_t('sip')}</a></li>
 			<li><a href="#audio_settings">${_t('audio')}</a></li>
 			<li><a href="#video_settings">${_t('video')}</a></li>
@@ -103,7 +103,7 @@
 					</div>
 				</div>
 
-				<div id="caller_id">
+				<div id="caller_id_device">
 					<div class="clearfix">
 						<label for="name">${_t('presence_id')}</label>
 						<div class="input">

--- a/whapps/voip/device/tmpl/fax.html
+++ b/whapps/voip/device/tmpl/fax.html
@@ -15,7 +15,7 @@
 	<div class="row">
 		<ul class="tabs" data-tabs="tabs">
 			<li class="active"><a href="#basic">${_t('basic')}</a></li>
-			<li><a href="#caller_id">${_t('caller_id')}</a></li>
+			<li><a href="#caller_id_device">${_t('caller_id')}</a></li>
 			<li><a href="#sip_settings">${_t('sip_settings')}</a></li>
 			<li><a href="#options">${_t('options')}</a></li>
 			<li><a href="#restrictions">${_t('restrictions')}</a></li>
@@ -101,7 +101,7 @@
 					</div>
 				</div>
 
-				<div id="caller_id">
+				<div id="caller_id_device">
 					<div class="clearfix">
 						<label for="name">${_t('presence_id')}</label>
 						<div class="input">

--- a/whapps/voip/device/tmpl/mobile.html
+++ b/whapps/voip/device/tmpl/mobile.html
@@ -15,7 +15,7 @@
 	<div class="row">
 		<ul class="tabs" data-tabs="tabs">
 			<li class="active"><a href="#basic">Basic</a></li>
-			<li><a href="#caller_id">Caller ID</a></li>
+			<li><a href="#caller_id_device">Caller ID</a></li>
 			<li><a href="#sip_settings">SIP Settings</a></li>
 			<li><a href="#audio_settings">Audio Settings</a></li>
 			<li><a href="#video_settings">Video Settings</a></li>
@@ -106,7 +106,7 @@
 					<input type="hidden" value="${data.device_type}" name="device_type"/>
 				</div>
 
-				<div id="caller_id">
+				<div id="caller_id_device">
 					<div class="clearfix">
 						<label for="name">${_t('presence_id')}</label>
 						<div class="input">

--- a/whapps/voip/device/tmpl/softphone.html
+++ b/whapps/voip/device/tmpl/softphone.html
@@ -15,7 +15,7 @@
 	<div class="row">
 		<ul class="tabs" data-tabs="tabs">
 			<li class="active"><a href="#basic">${_t('basic')}</a></li>
-			<li><a href="#caller_id">${_t('caller_id')}</a></li>
+			<li><a href="#caller_id_device">${_t('caller_id')}</a></li>
 			<li><a href="#sip_settings">${_t('sip_settings')}</a></li>
 			<li><a href="#audio_settings">${_t('audio_settings')}</a></li>
 			<li><a href="#video_settings">${_t('video_settings')}</a></li>
@@ -99,7 +99,7 @@
 					<input type="hidden" value="${data.device_type}" name="device_type"/>
 				</div>
 
-				<div id="caller_id">
+				<div id="caller_id_device">
 					<div class="clearfix">
 						<label for="name">${_t('presence_id')}</label>
 						<div class="input">

--- a/whapps/voip/user/tmpl/edit.html
+++ b/whapps/voip/user/tmpl/edit.html
@@ -15,7 +15,7 @@
 	<div class="row">
 		<ul class="tabs" data-tabs="tabs">
 		 	<li class="active"><a href="#basic">${_t('basic')}</a></li>
-		 	<li><a href="#caller_id">${_t('caller_id')}</a></li>
+		 	<li><a href="#caller_id_user">${_t('caller_id')}</a></li>
 		 	<li><a href="#options">${_t('options')}</a></li>
 		 	<li><a href="#call_forward">${_t('call_forward')}</a></li>
 		 	<li><a href="#password_management">${_t('password_management')}</a></li>
@@ -164,7 +164,7 @@
 	                </div>
 	            </div>
 
-	            <div id="caller_id">
+	            <div id="caller_id_user">
 	            	<div class="clearfix">
 						<label for="name">${_t('presence_id')}</label>
 						<div class="input">


### PR DESCRIPTION
When viewing a user and editing their devices in the popup window, clicking the caller_id div tab in the foreground currently also changes the background tab