### PR TITLE
Allow modules after pivot, as callflow can continue if pivot_failed returned

### DIFF
--- a/whapps/voip/callflow/callflow.js
+++ b/whapps/voip/callflow/callflow.js
@@ -3042,7 +3042,7 @@ winkstart.module('voip', 'callflow', {
                     rules: [
                         {
                             type: 'quantity',
-                            maxSize: '0'
+                            maxSize: '1'
                         }
                     ],
                     isUsable: 'true',


### PR DESCRIPTION
Partially from https://github.com/2600hz/kazoo/pull/1265, and because sometimes pivots could 404, pivot_failed messages tell Kazoo callflows to continue. However, Kazoo UI is currently disallowing modules to come after pivot