### PR TITLE
Fix cache busting - incorrect closure within _amplify.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,10 +75,8 @@
         <script type="text/javascript" src="js/external/jqplot/jqplot.pieRenderer.min.js"></script>
         <script type="text/javascript" src="js/external/jquery.fileupload.js"></script>
 
-        <script type="text/javascript" src="js/amplify/_amplify.js"></script>
-        <script>var _amplify = amplify;</script>
         <script type="text/javascript" src="js/amplify/amplify.core.js"></script>
-        <script>$.extend( amplify, _amplify );</script>
+        <script type="text/javascript" src="js/amplify/_amplify.js"></script>
         <script type="text/javascript" src="js/amplify/amplify.request.js"></script>
         <script type="text/javascript" src="js/amplify/amplify.request.poll.js"></script>
 


### PR DESCRIPTION
Before this PR, functions called from _amplify.js have a closure that only includes the snapshot of the amplify variable prior to amplify.core.js. Hence, later when the config.js file is loaded and the cache property of the global amplify is set, amplify.module.loadApp and amplify.module.loadModule can never cache bust. This change makes sure that the global amplify is used throughout. Makes the code respect the cache setting in config.js.
Tested thoroughly/used in production over a number of months.