### PR TITLE
KAZUI-124: fix highlighting e911 numbers in green for other providers than dash_e911

### DIFF
--- a/whapps/numbers/numbers_manager/numbers_manager.js
+++ b/whapps/numbers/numbers_manager/numbers_manager.js
@@ -505,14 +505,14 @@ winkstart.module('numbers', 'numbers_manager', {
 
                 if(phone_number[1]) {
                     THIS.get_number(phone_number[1], function(_data) {
-                        THIS.render_e911_dialog(_data.data.dash_e911 || {}, function(e911_data) {
-                            _data.data.dash_e911 = $.extend({}, _data.data.dash_e911, e911_data);
+                        THIS.render_e911_dialog(_data.data.e911 || {}, function(e911_data) {
+                            _data.data.e911 = $.extend({}, _data.data.e911, e911_data);
 
                             THIS.clean_phone_number_data(_data.data);
 
 							var updateNumber = function() {
 								THIS.update_number(phone_number[1], _data.data, function(_data_update) {
-                                        !($.isEmptyObject(_data.data.dash_e911)) ? $e911_cell.removeClass('inactive').addClass('active') : $e911_cell.removeClass('active').addClass('inactive');
+                                        !($.isEmptyObject(_data.data.e911)) ? $e911_cell.removeClass('inactive').addClass('active') : $e911_cell.removeClass('active').addClass('inactive');
                                     },
                                     function(_data_update) {
                                         winkstart.alert(_t('numbers_manager', 'failed_to_update_the_e911') + _data_update.message);
@@ -1144,7 +1144,7 @@ winkstart.module('numbers', 'numbers_manager', {
                         	var inbound = $.inArray('inbound_cnam', v.features) >= 0 ? true : false,
                         	    outbound = $.inArray('outbound_cnam', v.features) >= 0 ? true : false;
 
-                        	v.e911 = $.inArray('dash_e911', v.features) >= 0 ? true : false;
+                        	v.e911 = $.inArray('e911', v.features) >= 0 ? true : false;
                         	v.caller_id = { inbound: inbound, outbound: outbound };
 
 							if(winkstart.config.hasOwnProperty('hide_e911') && winkstart.config.hide_e911 === true) {

--- a/whapps/pbxs/pbxs_manager/pbxs_manager.js
+++ b/whapps/pbxs/pbxs_manager/pbxs_manager.js
@@ -751,15 +751,15 @@ winkstart.module('pbxs', 'pbxs_manager', {
 
                 if(phone_number[1]) {
                     THIS.get_number(phone_number[1], function(_data) {
-                        THIS.render_e911_dialog(_data.data.dash_e911 || {}, function(e911_data) {
-                            _data.data.dash_e911 = $.extend({}, _data.data.dash_e911, e911_data);
+                        THIS.render_e911_dialog(_data.data.e911 || {}, function(e911_data) {
+                            _data.data.e911 = $.extend({}, _data.data.e911, e911_data);
 
                             THIS.clean_phone_number_data(_data.data);
 
                             winkstart.confirm(_t('pbxs_manager', 'your_on_file_credit_card_will_immediately'),
                                 function() {
                                     THIS.update_number(phone_number[1], _data.data, function(_data_update) {
-                                            !($.isEmptyObject(_data.data.dash_e911)) ? $e911_cell.removeClass('inactive').addClass('active') : $e911_cell.removeClass('active').addClass('inactive');
+                                            !($.isEmptyObject(_data.data.e911)) ? $e911_cell.removeClass('inactive').addClass('active') : $e911_cell.removeClass('active').addClass('inactive');
                                         },
                                         function(_data_update) {
                                             winkstart.alert(_t('pbxs_manager', 'failed_to_update_the_e911')+_data_update.message);
@@ -1119,7 +1119,7 @@ winkstart.module('pbxs', 'pbxs_manager', {
 
                             var tab_data = [],
                                 cnam,
-                                dash_e911,
+                                e911,
                                 failover;
 
                             if('numbers' in _data_numbers.data) {
@@ -1127,13 +1127,13 @@ winkstart.module('pbxs', 'pbxs_manager', {
                                 	if(_data_numbers.data.numbers[k]) {
                                     	cnam = $.inArray('cnam', _data_numbers.data.numbers[k].features) > -1 ? true : false;
                                     	failover = $.inArray('failover', _data_numbers.data.numbers[k].features) > -1 ? true : false;
-                                    	dash_e911 = $.inArray('dash_e911', _data_numbers.data.numbers[k].features) > -1 ? true : false;
+                                    	e911 = $.inArray('e911', _data_numbers.data.numbers[k].features) > -1 ? true : false;
 
 										if(winkstart.config.hasOwnProperty('hide_e911') && winkstart.config.hide_e911 === true) {
                                         	tab_data.push(['lol', k, failover, cnam, _data_numbers.data.numbers[k].state]);
                                         }
                                         else {
-                                        	tab_data.push(['lol', k, failover, cnam, dash_e911, _data_numbers.data.numbers[k].state]);
+                                        	tab_data.push(['lol', k, failover, cnam, e911, _data_numbers.data.numbers[k].state]);
                                         }
                                 	}
                             	});


### PR DESCRIPTION
Recent Kazoo versions duplicate dash_e911 data for a phone number into the e911 field, so use that instead. Then e911 is highlighted for other providers