### PR TITLE
Normalize caller_id_options array to object for user

### DIFF
--- a/whapps/voip/user/user.js
+++ b/whapps/voip/user/user.js
@@ -951,6 +951,10 @@ winkstart.module('voip', 'user', {
                 data.directories = {};
             }
 
+            if($.isArray(data.caller_id_options)) {
+                data.caller_id_options = {};
+            }
+
             $.each(data.caller_id, function(key, val) {
                 $.each(val, function(_key, _val) {
                     if(_val == '') {


### PR DESCRIPTION
Empty caller_id_options array loaded from DB was causing issues when saving user details back to DB, with schema expecting caller_id_options as type object

Conflicts:
	whapps/voip/user/user.js

