### PR TITLE
KAZUI-123: Fixed reset password not working

### DIFF
--- a/whapps/auth/auth/tmpl/new_password.html
+++ b/whapps/auth/auth/tmpl/new_password.html
@@ -5,13 +5,6 @@
                 <form name="new_password_form" id="new_password_form">
                     <div class="pill-content">
                         <div class="clearfix">
-                            <label for="old_password">${_t('current_password')}</label>
-                            <div class="input">
-                                <input class="span4" id="old_password" type="password" name="old_password"/>
-                            </div>
-                        </div>
-						
-                        <div class="clearfix">
                             <label for="new_password1">${_t('new_password')}</label>
                             <div class="input">
                                 <input class="span4" id="new_password1" type="password" name="new_password1"/>

--- a/whapps/auth/auth/tmpl/recover_password.html
+++ b/whapps/auth/auth/tmpl/recover_password.html
@@ -24,20 +24,6 @@
                                 <input class="span4" id="account_name" name="account_name" type="text" placeholder="${_t('account_name')}" value=""/>
                             </div>
                         </div>
-
-                        <div class="clearfix">
-                            <label for="account_realm">${_t('account_realm')}</label>
-                            <div class="input">
-                                <input class="span4" id="account_realm" name="account_realm" type="text" placeholder="${_t('account_realm')}" value=""/>
-                            </div>
-                        </div>
-
-                        <div class="clearfix">
-                            <label for="phone_number">${_t('phone_number')}</label>
-                            <div class="input">
-                                <input class="span4" id="phone_number" name="phone_number" type="text" placeholder="${_t('phone_number')}" value=""/>
-                            </div>
-                        </div>
                     </div>
                 </form>
                 <div class="buttons-right">


### PR DESCRIPTION
- Added reset password function so that the user is flagged and we get an auth_token
- Removed account_realm, phone_number & old_password fields as they were superfluous
- Switched from POST to PATCH so I don’t need to send everything about the user
- Send back to login page after successful password change (clears recovery token from URL)
- Added ui_url to original recovery request so that Kazoo can build the recovery link