### PR TITLE
KAZUI-163: Added clearInterval function before setting new interval.

### DIFF
--- a/whapps/call_center/dashboard/dashboard.js
+++ b/whapps/call_center/dashboard/dashboard.js
@@ -243,6 +243,7 @@ winkstart.module('call_center', 'dashboard', {
                 map_agents[v.id] = 'logged_out';
             });
 
+            clearInterval(THIS.global_timer);
             THIS.global_timer = setInterval(huge_poll, polling_interval * 1000);
         },
 


### PR DESCRIPTION
clean_timers runs when the Call Center loads via render_dashboard. It runs again when you leave the dashboard via huge_poll. The issue is that render_dashboard sets up poll_agents to run in parallel and when you double click the Call Center button you can setup several occurrences of poll_agents that run after clean_timers has already occurred. If this happens then poll_agents will run setInterval multiple times and will overwrite the ID which is set to global_timer. This means that when clean_timers runs it will only run clearInterval on the latest ID in global_timer and will not stop any of the other intervals that may now be running with ID’s that we no longer know.

I decided to just add another clearInterval function before setInterval because running clean_timers again would clear the map_timers array which likely is not wanted.