### PR TITLE
KAZUI-128: Added config checking with notification

### DIFF
--- a/whapps/accounts/accounts_manager/accounts_manager.js
+++ b/whapps/accounts/accounts_manager/accounts_manager.js
@@ -1110,6 +1110,8 @@ winkstart.module('accounts', 'accounts_manager', {
 					}, callbacks.delete_error);
 				});
 			});
+
+		winkstart.apps.accounts.check_configuration(data.data, 'highlight');
 		},
 
 		render_list: function(parent) {

--- a/whapps/auth/auth.js
+++ b/whapps/auth/auth.js
@@ -654,7 +654,7 @@ winkstart.module('auth', 'auth',
                                 }
 
                                 winkstart.module.loadApp(k, function() {
-                                    this.init();
+									this.init(_data.data);
                                     winkstart.log('WhApps: Initializing ' + k);
                                 });
                             });

--- a/whapps/voip/account/account.js
+++ b/whapps/voip/account/account.js
@@ -496,6 +496,8 @@ winkstart.module('voip', 'account', {
 			if(winkstart.publish('call_center.render_account_fields', $(account_html), data, final_render)) {
 				final_render();
 			}
+
+		winkstart.apps.accounts.check_configuration(data.data, 'highlight');
         },
 
         activate: function(parent) {


### PR DESCRIPTION
- Added check config function to accounts whapp
- Added notification of settings issues for admins on login
- Added highlighting of required settings in Accounts (for child accounts) and in Hosted PBX->Account Details (for parent account).
- New checks can be added easily by adding a key/function to the configuration_checks object. The key name is also used as the ID for highlighting in settings.