### PR TITLE
KAZUI-70: Added ability to set/unset exit key on queues

### DIFF
--- a/whapps/call_center/queue/lang/en.js
+++ b/whapps/call_center/queue/lang/en.js
@@ -1,4 +1,6 @@
 window.translate['queue'] = {
+	caller_exit_key: 'Caller Exit Key',
+	caller_exit_key_data_content: 'Key caller can press while on hold to exit the queue and continue in the callflow.',
 	manage_queues: "Manage Queues",
 	queue: "Queue",
 	queue_tip: "Direct a Caller to a Queue.",

--- a/whapps/call_center/queue/queue.js
+++ b/whapps/call_center/queue/queue.js
@@ -25,7 +25,8 @@ winkstart.module('call_center', 'queue', {
         },
 
         validation: [
-            { name: '#name', regex: /.+/ }
+		{ name: '#name', regex: /.+/ },
+		{ name: '#caller_exit_key', regex: /^[0-9*#]{0,1}$/ }
         ],
 
         resources: {
@@ -589,6 +590,9 @@ winkstart.module('call_center', 'queue', {
         },
 
         normalize_data: function(form_data) {
+		if (typeof form_data.caller_exit_key === 'string' && form_data.caller_exit_key.length === 0) {
+			delete form_data.caller_exit_key;
+		}
             delete form_data.users;
             return form_data;
         },

--- a/whapps/call_center/queue/tmpl/edit.html
+++ b/whapps/call_center/queue/tmpl/edit.html
@@ -114,6 +114,13 @@
 							<input class="span2" id="connection_timeout" name="connection_timeout" type="text" placeholder="30" value="${data.connection_timeout}" rel="popover" data-content="${_t('max_hold_time_data_content')}"/>
 						</div>
                     </div>
+
+					<div class="clearfix">
+						<label for="caller_exit_key">${_t('caller_exit_key')}</label>
+						<div class="input">
+							<input class="span1" id="caller_exit_key" name="caller_exit_key" type="text" placeholder="#" value="${data.caller_exit_key}" rel="popover" data-content="${_t('caller_exit_key_data_content')}"/>
+						</div>
+					</div>
                     
                     <div class="clearfix">
                         <div class="input">


### PR DESCRIPTION
- Added input box with allowed keys (0-9 # *)
- Default is unset and box can be cleared to unset if set
- Tested with Telephone app locally and it worked (Ends call within 1 second of being pressed)