### PR TITLE
KAZUI-197: Moved landline condition to allow different defaults

### DIFF
--- a/whapps/voip/device/device.js
+++ b/whapps/voip/device/device.js
@@ -807,14 +807,19 @@ winkstart.module('voip', 'device', {
         },
 
         format_data: function(data) {
-            if(data.data.device_type === 'smartphone' || data.data.device_type === 'landline' || data.data.device_type === 'cellphone') {
+		if (data.data.device_type === 'smartphone' || data.data.device_type === 'cellphone') {
                 data.data.call_forward = {
                     enabled: true,
                     require_keypress: true,
                     keep_caller_id: true
                 };
-            }
-            else {
+		} else if (data.data.device_type === 'landline') {
+			data.data.call_forward = {
+				enabled: true,
+				require_keypress: false,
+				keep_caller_id: true
+			};
+		} else {
                 data.data.call_forward = {
                     enabled: false
                 };


### PR DESCRIPTION
For our uses we typically only create a landline device to forward to a number not on our network and our customers need to be able to answer the calls right away. Because of this we have decided require pin should be disabled by default. We have made the change internally and decided this could be relevant to others so I have submitted a PR.