### PR TITLE
KAZUI-201: Don't show notification for resellers

### DIFF
--- a/whapps/accounts/accounts.js
+++ b/whapps/accounts/accounts.js
@@ -43,7 +43,7 @@ function(account_config) {
 
         winkstart.registerResources(THIS.__whapp, THIS.config.resources);
 
-	if (winkstart.apps.auth.role === 'admin') {
+	if (winkstart.apps.auth.role === 'admin' && !winkstart.apps.auth.is_reseller) {
 		THIS.check_configuration(account_config, 'notify');
 	}
 


### PR DESCRIPTION
We've decided that the new feature of notifying admins about things such as caller ID is not needed for resellers. If in the future we want notifications for non-admins or resellers we will adjust this condition.