### PR TITLE
Add the ability to set a one-time TIME OF DAY instead of yearly

### DIFF
--- a/whapps/voip/timeofday/timeofday.js
+++ b/whapps/voip/timeofday/timeofday.js
@@ -159,7 +159,7 @@ winkstart.module('voip', 'timeofday', {
                         ],
 
                         cycle: [
-                            { id: 'date', value: 'Date' },
+					{ id: 'date', value: 'Date' },
                             { id: 'weekly', value: 'Weekly' },
                             { id: 'monthly', value:'Monthly' },
                             { id: 'yearly', value:'Yearly' }
@@ -271,9 +271,9 @@ winkstart.module('voip', 'timeofday', {
             $('#weekdays', timeofday_html).hide();
             $('#specific_day', timeofday_html).hide();
 
-            $('#every', timeofday_html).show();
-            $('#on', timeofday_html).show();
-            $('#start_date_label', timeofday_html).text(_t('timeofday', 'start_date'));
+		$('#every', timeofday_html).show();
+		$('#on', timeofday_html).show();
+		$('#start_date_label', timeofday_html).text(_t('timeofday', 'start_date'));
 
             if(data.data.id == undefined) {
                 $('#weekly_every', timeofday_html).show();
@@ -287,10 +287,10 @@ winkstart.module('voip', 'timeofday', {
                     } else {
                         $('#weekdays', timeofday_html).show();
                     }
-                } else if(data.data.cycle == 'date') {
-                    $('#every', timeofday_html).hide();
-                    $('#on', timeofday_html).hide();
-                    $('#start_date_label', timeofday_html).text(_t('timeofday', 'on'));
+			} else if (data.data.cycle === 'date') {
+				$('#every', timeofday_html).hide();
+				$('#on', timeofday_html).hide();
+				$('#start_date_label', timeofday_html).text(_t('timeofday', 'on'));
 
                 } else if(data.data.cycle == 'yearly') {
                     $('#yearly_every', timeofday_html).show();
@@ -329,16 +329,16 @@ winkstart.module('voip', 'timeofday', {
                 $('#weekdays', timeofday_html).hide();
                 $('#specific_day', timeofday_html).hide();
 
-                $('#every', timeofday_html).show();
-                $('#on', timeofday_html).show();
-                $('#start_date_label', timeofday_html).text(_t('timeofday', 'start_date'));
+			$('#every', timeofday_html).show();
+			$('#on', timeofday_html).show();
+			$('#start_date_label', timeofday_html).text(_t('timeofday', 'start_date'));
 
                 switch($(this).val()) {
-                    case 'date':
-                        $('#every', timeofday_html).hide();
-                        $('#on', timeofday_html).hide();
-                        $('#start_date_label', timeofday_html).text(_t('timeofday', 'on'));
-                        break;
+				case 'date':
+					$('#every', timeofday_html).hide();
+					$('#on', timeofday_html).hide();
+					$('#start_date_label', timeofday_html).text(_t('timeofday', 'on'));
+					break;
 
                     case 'yearly':
                         $('#yearly_every', timeofday_html).show();

--- a/whapps/voip/timeofday/timeofday.js
+++ b/whapps/voip/timeofday/timeofday.js
@@ -159,6 +159,7 @@ winkstart.module('voip', 'timeofday', {
                         ],
 
                         cycle: [
+                            { id: 'date', value: 'Date' },
                             { id: 'weekly', value: 'Weekly' },
                             { id: 'monthly', value:'Monthly' },
                             { id: 'yearly', value:'Yearly' }
@@ -270,6 +271,10 @@ winkstart.module('voip', 'timeofday', {
             $('#weekdays', timeofday_html).hide();
             $('#specific_day', timeofday_html).hide();
 
+            $('#every', timeofday_html).show();
+            $('#on', timeofday_html).show();
+            $('#start_date_label', timeofday_html).text(_t('timeofday', 'start_date'));
+
             if(data.data.id == undefined) {
                 $('#weekly_every', timeofday_html).show();
                 $('#days_checkboxes', timeofday_html).show();
@@ -282,6 +287,11 @@ winkstart.module('voip', 'timeofday', {
                     } else {
                         $('#weekdays', timeofday_html).show();
                     }
+                } else if(data.data.cycle == 'date') {
+                    $('#every', timeofday_html).hide();
+                    $('#on', timeofday_html).hide();
+                    $('#start_date_label', timeofday_html).text(_t('timeofday', 'on'));
+
                 } else if(data.data.cycle == 'yearly') {
                     $('#yearly_every', timeofday_html).show();
                     $('#ordinal', timeofday_html).show();
@@ -319,7 +329,17 @@ winkstart.module('voip', 'timeofday', {
                 $('#weekdays', timeofday_html).hide();
                 $('#specific_day', timeofday_html).hide();
 
+                $('#every', timeofday_html).show();
+                $('#on', timeofday_html).show();
+                $('#start_date_label', timeofday_html).text(_t('timeofday', 'start_date'));
+
                 switch($(this).val()) {
+                    case 'date':
+                        $('#every', timeofday_html).hide();
+                        $('#on', timeofday_html).hide();
+                        $('#start_date_label', timeofday_html).text(_t('timeofday', 'on'));
+                        break;
+
                     case 'yearly':
                         $('#yearly_every', timeofday_html).show();
                         $('#ordinal', timeofday_html).show();

--- a/whapps/voip/timeofday/tmpl/edit.html
+++ b/whapps/voip/timeofday/tmpl/edit.html
@@ -114,7 +114,7 @@
                     </div>
 
                     <div class="clearfix">
-                        <label for="day">${_t('start_date')}</label>
+                        <label for="day" id="start_date_label">${_t('start_date')}</label>
                         <div class="input">
                             <input class="span4" id="start_date" name="start_date" type="text" placeholder="03/12/2012" value="${data.start_date}" rel="popover" data-content="${_t('start_date_data_content')}"/>
                         </div>


### PR DESCRIPTION
Previously in the Kazoo-ui there has been no way to set a single time of day that did not repeat yearly. This is helpful for one-time holidays or one-time re-routing of calls. 

This change allows a user to set a single date with a year value to ensure the time-of-day only occurs only once. 