### PR TITLE
KAZUI-210: Park call flow module with max slots input

### DIFF
--- a/whapps/voip/callflow/callflow.js
+++ b/whapps/voip/callflow/callflow.js
@@ -8,6 +8,7 @@ winkstart.module('voip', 'callflow', {
         ],
 
         templates: {
+		park_callflow: 'tmpl/park_callflow.html',
             callflow: 'tmpl/callflow.html',
             callflow_main: 'tmpl/callflow_main.html',
             branch: 'tmpl/branch.html',
@@ -3403,7 +3404,61 @@ winkstart.module('voip', 'callflow', {
                             }
                         );
                     }
-                }
+			},
+			'park[action=direct_park]': {
+				name: _t('callflow', 'park'),
+				icon: 'hand',
+				category: _t('config', 'advanced_cat'),
+				module: 'park',
+				tip: _t('callflow', 'park_tip'),
+				data: {
+					action: 'direct_park'
+				},
+				rules: [
+					{
+						type: 'quantity',
+						maxSize: '1'
+					}
+				],
+				isUsable: 'true',
+				caption: function(node) {
+					var max_slot_number = node.getMetadata('max_slot_number');
+					return max_slot_number ? _t('callflow', 'park_max_slot_number') + ': ' + (max_slot_number - 100) : '';
+				},
+				edit: function(node, callback) {
+					var popup, popup_html;
+
+					popup_html = THIS.templates.park_callflow.tmpl({
+						_t: function(param) {
+							return window.translate.callflow[param];
+						},
+						data_park: {
+							'max_slot_number': node.getMetadata('max_slot_number') ? node.getMetadata('max_slot_number') - 100 : ''
+						}
+					});
+
+					$('#add', popup_html).click(function() {
+						var max_slot_number = parseInt($('#park_max_slot_number_input', popup_html).val());
+						if (!isNaN(max_slot_number)) {
+							node.setMetadata('max_slot_number', max_slot_number + 100);
+						} else {
+							node.deleteMetadata('max_slot_number');
+						}
+						node.caption = max_slot_number ? _t('callflow', 'park_max_slot_number') + ': ' + max_slot_number : '';
+						popup.dialog('close');
+					});
+
+					popup = winkstart.dialog(popup_html, {
+						title: _t('callflow', 'park'),
+						minHeight: '0',
+						beforeClose: function() {
+							if (typeof callback === 'function') {
+								callback();
+							}
+						}
+					});
+				}
+			}
             });
 
             /* Migration callflows, fixes our goofs. To be removed eventually */

--- a/whapps/voip/callflow/lang/en.js
+++ b/whapps/voip/callflow/lang/en.js
@@ -1,4 +1,9 @@
 window.translate['callflow'] = {
+	ok: 'OK',
+	park: 'Park',
+	park_tip: 'Places a call in a numbered slot where it will remain until it is retrieved or the caller hangs up.',
+	park_max_slot_number: 'Max Slots',
+	park_max_slot_number_explanation: 'Continue past this module if the selected slot number exceeds this number. Used to restrict the max number of auto-generated slot numbers. Slots numbers start at 101.',
 	duplicate_callflow: "Duplicate callflow",
 	css_callflow: "css/callflow.css",
 	delete_callflow: "Delete callflow",

--- a/whapps/voip/callflow/tmpl/park_callflow.html
+++ b/whapps/voip/callflow/tmpl/park_callflow.html
@@ -1,0 +1,18 @@
+<div>
+	<div class="dialog_popup">
+		<h1>${_t('park')}</h1>
+		<form name="form" method="post" action="#">
+			<div class="explanation">${_t('park_max_slot_number_explanation')}</div>
+
+			<div class="form_content">
+				<div class="popup_field">
+					<label for="park_max_slot_number_input">${_t('park_max_slot_number')}: </label>
+					<input type="text" id="park_max_slot_number_input" class="medium" value="${data_park.max_slot_number}"/>
+				</div>
+			</div>
+		</form>
+		<div class="buttons-center">
+			<button id="add" class="btn primary">${_t('ok')}</button>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
This adds a 'Park' module to the call flows which will 'direct park' calls and allows setting a maximum number of "parking" slots. The max slots part of this module requires the back-end change which is currently in PR (https://github.com/2600hz/kazoo/pull/5757).