### PR TITLE
KAZUI-240: es5/no-shorthand-properties

### DIFF
--- a/whapps/voip/callflow/callflow.js
+++ b/whapps/voip/callflow/callflow.js
@@ -749,7 +749,7 @@ winkstart.module('voip', 'callflow', {
             THIS.flow.nodes = THIS.flow.root.nodes();
         },
 
-	callflow_placeholder_name(flow) {
+	callflow_placeholder_name: function(flow) {
 		if (flow.nodes && flow.nodes[1] && flow.nodes[1].module === 'user') {
 			var number = flow.numbers && flow.numbers[0] !== '' ? flow.numbers[0] : '(no number)',
 				name = flow.nodes[1].caption ? ', ' + flow.nodes[1].caption : '';


### PR DESCRIPTION
I accidentally created this function using the shorthand syntax (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) which is actually not supported in ECMAScript 5, so this function would not work properly with IE9-10. This 1 line changes fixes that issue. Sorry for the oversight.