### PR TITLE
KAZUI-248: authenticate with Kazoo with a case-insensitive username

### DIFF
--- a/whapps/auth/auth.js
+++ b/whapps/auth/auth.js
@@ -384,7 +384,7 @@ winkstart.module('auth', 'auth',
             $('.login', contentDiv).click(function(event) {
                 event.preventDefault(); // Don't run the usual "click" handler
 
-                var login_username = $('#login', contentDiv).val(),
+				var login_username = $('#login', contentDiv).val().toLowerCase(),
                     login_password = $('#password', contentDiv).val(),
                     login_account_name = $('#account_name', contentDiv).val(),
                     hashed_creds = $.md5(login_username + ':' + login_password),


### PR DESCRIPTION
Since the username is normalized to lowercase, it should also be possible to authenticate with any case.