### PR TITLE
Use a global cache busting timestamp

### DIFF
--- a/config/load.js
+++ b/config/load.js
@@ -8,10 +8,6 @@ if (language == 'auto'){
 
 window.language = language;
 
-function loadScript(url){
-	$LAB.script(url);
-}
-
 _t = function(module, param){				//Global function translate
 	if(module && param) {
 		response = window.translate[module][param]
@@ -71,9 +67,9 @@ var langUrls = [
 ];
 
 function loadLanguages(language) {
-	for(var i = 0; i < langUrls.length; i++){
-	 	 loadScript(langUrls[i]+'/lang/'+language+'.js');
-	}
+    for (var i = 0; i < langUrls.length; i++) {
+        $LAB.script(langUrls[i] + '/lang/' + language + '.js?_=' + CACHE_BUSTER);
+    }
 }
 
 loadLanguages('en');
@@ -85,5 +81,3 @@ if(window.language !== 'en') {
 $LAB.script('config/config.js')
 	.wait()
 	.script('config/loadFavicon.js');
-
-

--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
 
                     return url_data;
                 }();
+
+            var CACHE_BUSTER = function() {
+                var now = new Date();
+                var this_minute = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours(), now.getMinutes());
+                return this_minute.getTime();
+            }();
         </script>
 
         <script type="text/javascript" src="js/external/jquery-1.6.2.min.js"></script>
@@ -93,4 +99,3 @@
     <body class="background">
     </body>
 </html>
-

--- a/js/amplify/_amplify.js
+++ b/js/amplify/_amplify.js
@@ -489,35 +489,23 @@ amplify.module = function(whapp, module, config, construct, methods) {
 };
 
 amplify.module.loadApp = function(whapp, callback) {
-    // Cache buster
+    var src = 'whapps/' + whapp + '/' + whapp + '.js';
     if (amplify.cache === false) {
-	$LAB.script('whapps/' + whapp + '/' + whapp + '.js?_=' + (new Date()))
-		.wait(function() {
-			callback.call( amplify.module(whapp, whapp) );
-		});
-    } else {
-	$LAB.script('whapps/' + whapp + '/' + whapp + '.js')
-		.wait(function() {
-			callback.call( amplify.module(whapp, whapp) );
-		});
+        src += '?_=' + CACHE_BUSTER;
     }
+    $LAB.script(src).wait(function() {
+        callback.call(amplify.module(whapp, whapp));
+    });
 };
 
 amplify.module.loadModule = function(whapp, module, callback) {
-	//console.log("locale " + module + " loaded");
+    var src = 'whapps/' + whapp + '/' + module + '/' + module + '.js';
     if (amplify.cache === false) {
-	$LAB.script('whapps/' + whapp + '/' + module + '/' + module + '.js?_=' + (new Date()))
-		.wait(function() {
-			//console.log(module + " loaded");
-			callback.call( amplify.module(whapp, module) );
-		});
-    } else {
-	$LAB.script('whapps/' + whapp + '/' + module + '/' + module + '.js')
-		.wait(function() {
-			//console.log(module + " loaded with cache");
-			callback.call( amplify.module(whapp, module) );
-		});
+        src += '?_=' + CACHE_BUSTER;
     }
+    $LAB.script(src).wait(function() {
+        callback.call(amplify.module(whapp, module));
+    });
 };
 
 // This is the method that may be overloaded to change the way in which the module is
@@ -527,4 +515,3 @@ amplify.module.constructor = function(args, callback) { callback(); };
 amplify.module.using = amplify.module.loadApp;
 
 })( this.amplify = this.amplify || {}, jQuery );
-


### PR DESCRIPTION
Generate a new timestamp every minute (instead of every second or millisecond). Use that timestamp when loading language files and whapp/module files.
Also, made the code a bit more DRY.