### PR TITLE
KAZUI-277: call history date sort by unix_timestamp_micro

### DIFF
--- a/js/winkstart-tables.js
+++ b/js/winkstart-tables.js
@@ -1,5 +1,39 @@
 (function(winkstart, amplify, undefined) {
 
+	/**
+	 * Type used for numeric datatables columns that are displayed as formatted text,
+	 * but should still be sorted by their original numeric values.
+	 * Example structure:
+	 * {
+	 *   display: 'text to display',
+	 *   value: 1234
+	 * }
+	 *
+	 * @typedef {Object} NumericWrapper
+	 * @property {string} display The formatted text representation of the value
+	 * @property {number} value The actual numeric value
+	 */
+
+	/**
+	 * Ascending sort function for NumericWrapper-typed datatables columns
+	 *
+	 * @param {NumericWrapper} a
+	 * @param {NumericWrapper} b
+	 */
+	$.fn.dataTableExt.oSort['numeric-wrapper-obj-asc'] = function(a, b) {
+		return a.value - b.value;
+	};
+
+	/**
+	 * Descending sort function for NumericWrapper-typed datatables columns
+	 *
+	 * @param {NumericWrapper} a
+	 * @param {NumericWrapper} b
+	 */
+	$.fn.dataTableExt.oSort['numeric-wrapper-obj-desc'] = function(a, b) {
+		return b.value - a.value;
+	};
+
 	winkstart.table = {
 		create: function(name, $element, columns, data, options) {
 			var THIS = this;

--- a/whapps/voip/cdr/cdr.js
+++ b/whapps/voip/cdr/cdr.js
@@ -184,7 +184,7 @@ function (args) {
 					/*'<a href="' + winkstart.config.logs_web_server_url + web_browser_id + '.log" target="_blank">Log</a>&nbsp;|&nbsp;' +*/
 					'<a href="javascript:void(0);" data-cdr_id="' + cdr_id + '"  class="table_detail_link">' + _t('cdr', 'details') + '</a>',
 					cost,
-					humanFullDate,
+					{ display: humanFullDate, value: this.unix_timestamp_micro || this.timestamp },
 					cdr_id,
 					this.billing_seconds || ''
 				]);
@@ -327,7 +327,7 @@ function (args) {
 					/*'<a href="' + winkstart.config.logs_web_server_url + web_browser_id + '.log" target="_blank">Log</a>&nbsp;|&nbsp;' +*/
 					'<a href="javascript:void(0);" data-cdr_id="' + cdr_id + '"  class="table_detail_link">' + _t('cdr', 'details') + '</a>',
 					cost,
-					humanFullDate,
+					{ display: humanFullDate, value: this.unix_timestamp_micro || this.timestamp },
 					cdr_id,
 					this.billing_seconds || ''
 				]);
@@ -398,7 +398,12 @@ function (args) {
 					'sTitle': _t('cdr', 'cost_stitle')
 				},
 				{
-					'sTitle': _t('cdr', 'date_stitle')
+					'sTitle': _t('cdr', 'date_stitle'),
+					'sType': 'numeric-wrapper-obj',
+					'fnRender': function(oObj) {
+						return oObj.aData[oObj.iDataColumn].display;
+					},
+					'bUseRendered': false
 				},
 				{
 					'sTitle': _t('cdr', 'cdr_id_stitle'),


### PR DESCRIPTION
- consistent ordering of inbound/outbound legs

Backwards compatible, but takes advantage of https://github.com/2600hz/kazoo/pull/6336