### PR TITLE
KAZUI-287: Fixes to user edit form

### DIFF
--- a/whapps/voip/user/tmpl/edit.html
+++ b/whapps/voip/user/tmpl/edit.html
@@ -586,7 +586,7 @@
                     <h3>${_t('queue_membership')}</h3>
 
                     <div class="clearfix">
-                        <button class="btn primary" id="add_queue">${_t('add_queue')}</button>
+                        <button class="btn primary" type="button" id="add_queue">${_t('add_queue')}</button>
                         <table id="queues-grid" class="display"></table>
                     </div>
                 </div>
@@ -635,7 +635,7 @@
             {{if data.id}}
             <button class="btn danger user-delete">${_t('delete')}</button>
             {{/if}}
-            <button class="btn success user-save">${_t('save')}</button>
+            <button class="btn success user-save" form="user-form">${_t('save')}</button>
         </div>
     </div>
 </div>

--- a/whapps/voip/user/user.js
+++ b/whapps/voip/user/user.js
@@ -884,7 +884,7 @@ function(args) {
 		}
 
 		// Add queue to user
-		$('#add_queue').click(function(event) {
+		$('#add_queue', parent).click(function(event) {
 			event.preventDefault();
 
 			var queueCount = Object.keys(otherQueues).length,


### PR DESCRIPTION
- Changed Add Queue type to button so that it’s not also considered a submit type
- Assigned Save button to the user form so that pressing enter on a form input triggers submit (HTML5 Required)
- Brought back parent reference in jQuery selector as it seems to be needed for proper association