### PR TITLE
KAZUI-298: Prevent end-of-line changes to external source files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+
+js/external/** -text


### PR DESCRIPTION
Adds 'js/externals/** -text' to the .gitattributes file to keep end-of-line without changes, since these files come from other sources. Some of these files can otherwise be seen by Git as changed files on checkout.

@danielfinke please review.